### PR TITLE
compute jobs with minimal input

### DIFF
--- a/docs/compute.rst
+++ b/docs/compute.rst
@@ -25,10 +25,6 @@ Compute Input File
 The input file contains the following mandatory keywords:
 ::
 
-   # URL to the insilico server
-   url:
-      http://localhost:8080/graphql
-
    # Name of the collection to compute
    collection_name:
       "PBE/DZVP"
@@ -49,8 +45,8 @@ Other optional keywords are:
    workdir:
       /path/to/workdir
 
-   # Maximum number of jobs to request (default: 10)
-   max_jobs:
+   # Number of jobs to request and run (default: 10)
+   jobs:
       5
       
 .. _schedule:

--- a/moka/cli.py
+++ b/moka/cli.py
@@ -53,7 +53,7 @@ def parse_user_arguments() -> Tuple[str, Options]:
 
     # Common arguments
     parent_parser = argparse.ArgumentParser(add_help=False)
-    
+
     # you should provide either the input file with the arguments
     # or each argument in the command line
     group = parent_parser.add_mutually_exclusive_group()
@@ -61,17 +61,17 @@ def parse_user_arguments() -> Tuple[str, Options]:
     group.add_argument("-i", "--input", type=exists, help="Yaml input file")
     group.add_argument("-w", "--web", default=DEFAULT_WEB, help="Web Service URL")
 
+    # Command line arguments share
+    collection_parser = argparse.ArgumentParser(add_help=False)
+    collection_parser.add_argument("-c", "--collection_name", help="Collection name")
+
     # Login into the web service
-    login_parser = subparsers.add_parser("login", help="Log in to Insilico web service")
+    login_parser = subparsers.add_parser("login", help="Log in to the Insilico web service")
     login_parser.add_argument("-w", "--web", default=DEFAULT_WEB, help="Web Service URL")
     login_parser.add_argument("-t", "--token", required=True, help="GitHub access Token")
 
-    # Add jobs to a collection
-    collection_parser = argparse.ArgumentParser(add_help=False)
-    collection_parser.add_argument("--collection_name", help="Collection name")
-
     # Request new jobs to run from the database
-    subparsers.add_parser("compute", help="compute available jobs", parents=[parent_parser])
+    subparsers.add_parser("compute", help="Compute available jobs", parents=[parent_parser, collection_parser])
 
     # Report properties to the database
     subparsers.add_parser(
@@ -79,7 +79,7 @@ def parse_user_arguments() -> Tuple[str, Options]:
 
     # Request data from the database
     subparsers.add_parser(
-        "query", help="query some properties from the database",
+        "query", help="Query some properties from the database",
         parents=[parent_parser, collection_parser])
 
     # Add new Job to the database

--- a/moka/input_validation.py
+++ b/moka/input_validation.py
@@ -60,7 +60,7 @@ COMPUTE_SCHEMA = Schema({
         str, lambda w: w in {"AVAILABLE", "DONE", "FAILED", "RUNNING", "RESEVERED"}),
 
     # Maximum number of jobs to compute
-    Optional("max_jobs", default=10): int,
+    Optional("jobs", default=10): int,
 
     # Request either the smallest or largest available jobs
     Optional("job_size", default=None): Or(None, is_in_array_uppercase({"SMALL", "LARGE"}))

--- a/tests/files/input_test_compute.yml
+++ b/tests/files/input_test_compute.yml
@@ -4,4 +4,5 @@ command: mock_workflow
 
 job_size: small
 
-max_jobs: 10
+# Number of jobs to run
+jobs: 10


### PR DESCRIPTION
##Change
* replace the compute `max_jobs` keyword with `jobs`
* Allow to pass the `collection_name` to compute via the CLI arguments